### PR TITLE
Implement Wish Creation Endpoint

### DIFF
--- a/src/main/java/com/ofilipecode/wish_list/controller/UserController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/UserController.java
@@ -21,7 +21,7 @@ import com.ofilipecode.wish_list.service.UserService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("wishlist")
+@RequestMapping("user")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
@@ -1,0 +1,35 @@
+package com.ofilipecode.wish_list.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ofilipecode.wish_list.dtos.wish.CreateWishDTO;
+import com.ofilipecode.wish_list.dtos.wish.WishResponseDTO;
+import com.ofilipecode.wish_list.service.WishService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/wishlist")
+@RequiredArgsConstructor
+public class WishController {
+    
+    private final WishService service;
+
+    @PostMapping("{id}")
+    public ResponseEntity<WishResponseDTO> createWish(@PathVariable UUID id, @RequestBody @Valid CreateWishDTO dto) {
+
+        WishResponseDTO response = service.createWish(id, dto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+}

--- a/src/main/java/com/ofilipecode/wish_list/dtos/wish/CreateWishDTO.java
+++ b/src/main/java/com/ofilipecode/wish_list/dtos/wish/CreateWishDTO.java
@@ -1,0 +1,36 @@
+package com.ofilipecode.wish_list.dtos.wish;
+
+import java.math.BigDecimal;
+
+import com.ofilipecode.wish_list.shared.enums.PriorityEnum;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateWishDTO(
+
+    @NotBlank(message = "Title is required")
+    @Size(min = 5, max = 50, message = "Title must be between 5 and 50 characters")
+    String title, 
+
+    @NotBlank(message = "Description is required")
+    @Size(min = 10, max = 255, message = "Description must be between 10 and 255 characters")
+    String description, 
+
+    @Pattern(
+        regexp = "^(http|https)://.*$",
+        message = "Link must be a valid URL starting with http or https"
+    )
+    String link, 
+
+    @NotNull(message = "Price is required")
+    @DecimalMin(value = "0.01", message = "Price must be greater than zero")
+    BigDecimal price, 
+
+    @NotNull(message = "Priority is required")
+    PriorityEnum priority) {
+    
+}

--- a/src/main/java/com/ofilipecode/wish_list/dtos/wish/WishResponseDTO.java
+++ b/src/main/java/com/ofilipecode/wish_list/dtos/wish/WishResponseDTO.java
@@ -1,0 +1,19 @@
+package com.ofilipecode.wish_list.dtos.wish;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.ofilipecode.wish_list.shared.enums.PriorityEnum;
+
+public record WishResponseDTO(
+
+    UUID id,
+    String title,
+    String description, 
+    String link, 
+    BigDecimal price, 
+    PriorityEnum priority,
+    UUID userID
+    ) {
+    
+}

--- a/src/main/java/com/ofilipecode/wish_list/repository/WishRepository.java
+++ b/src/main/java/com/ofilipecode/wish_list/repository/WishRepository.java
@@ -1,0 +1,11 @@
+package com.ofilipecode.wish_list.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ofilipecode.wish_list.model.Wish;
+
+public interface WishRepository extends JpaRepository<Wish, UUID> {
+    
+}

--- a/src/main/java/com/ofilipecode/wish_list/repository/WishRepository.java
+++ b/src/main/java/com/ofilipecode/wish_list/repository/WishRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ofilipecode.wish_list.model.Wish;
 
 public interface WishRepository extends JpaRepository<Wish, UUID> {
-    
 }

--- a/src/main/java/com/ofilipecode/wish_list/service/WishService.java
+++ b/src/main/java/com/ofilipecode/wish_list/service/WishService.java
@@ -1,0 +1,48 @@
+package com.ofilipecode.wish_list.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.ofilipecode.wish_list.dtos.wish.CreateWishDTO;
+import com.ofilipecode.wish_list.dtos.wish.WishResponseDTO;
+import com.ofilipecode.wish_list.model.User;
+import com.ofilipecode.wish_list.model.Wish;
+import com.ofilipecode.wish_list.repository.UserRepository;
+import com.ofilipecode.wish_list.repository.WishRepository;
+import com.ofilipecode.wish_list.shared.exceptions.UserNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WishService {
+
+    private final WishRepository repository;
+    private final UserRepository userRepository;
+
+    public WishResponseDTO createWish(UUID userId, CreateWishDTO dto) {
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("User not found!"));
+
+        Wish wish = new Wish();
+        wish.setTitle(dto.title());
+        wish.setDescription(dto.description());
+        wish.setLink(dto.link());
+        wish.setPrice(dto.price());
+        wish.setPriority(dto.priority());
+        wish.setUser(user);
+
+        Wish savedWish = repository.save(wish);
+
+        return new WishResponseDTO(
+            savedWish.getId(),
+            savedWish.getTitle(),
+            savedWish.getDescription(),
+            savedWish.getLink(),
+            savedWish.getPrice(),
+            savedWish.getPriority(),
+            savedWish.getUser().getId()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the functionality to create a new Wish associated with an existing User, including data validation and response DTO mapping. The creation is handled via the POST /wishlist/{userId} endpoint.

✅ Features Implemented

Input DTO: CreateWishDTO with Bean Validation annotations for field validation.

Response DTO: WishResponseDTO returning the essential data of the created Wish.

Service: Business logic to create a Wish and associate it with a User.

Controller: POST /wishlist/{userId} endpoint to handle the creation request.

🧪 How to Test

    Send a POST request to the endpoint:

POST /wishlist/{userId}

Sample request body:

{
  "title": "Gaming Chair",
  "description": "Ergonomic chair for home office use",
  "link": "https://example.com/chair",
  "price": 899.90,
  "priority": "HIGH"
}

    Expected response (HTTP 201):

{
  "id": "UUID of the created wish",
  "title": "Gaming Chair",
  "description": "Ergonomic chair for home office use",
  "link": "https://example.com/chair",
  "price": 899.90,
  "priority": "HIGH",
  "createdAt": "2025-05-28T18:00:00"
}

