### PR TITLE
Wish endpoint: update, delete and get wish by id

### DIFF
--- a/src/main/java/com/ofilipecode/wish_list/controller/UserController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
     public ResponseEntity<Object> deleteUser(@PathVariable String id) {
         UUID userId = UUID.fromString(id);
         
-        if (id == null) {
+        if (userId == null) {
             return ResponseEntity.notFound().build();
         } else {
             service.deleteById(userId);

--- a/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
@@ -1,9 +1,10 @@
 package com.ofilipecode.wish_list.controller;
 
+import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,5 +32,33 @@ public class WishController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @GetMapping("{id}")
+    public ResponseEntity<WishResponseDTO> getWishById(@PathVariable String id) {
+        
+        UUID wishId = UUID.fromString(id);
+
+        Optional<WishResponseDTO> wishResponseDTO = service.getWishById(wishId);
+
+        if (wishResponseDTO.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(wishResponseDTO.get());
+    }
+
+    public ResponseEntity<Object> deleleWishById(@PathVariable String id) {
+        UUID wishId = UUID.fromString(id);
+
+        if (wishId == null) {
+            return ResponseEntity.notFound().build();
+        } else {
+            service.deleteById(wishId);
+            return ResponseEntity.noContent().build();
+        }
+
+    }
+
+    
     
 }

--- a/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
@@ -8,11 +8,13 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ofilipecode.wish_list.dtos.wish.CreateWishDTO;
+import com.ofilipecode.wish_list.dtos.wish.UpdateWishDTO;
 import com.ofilipecode.wish_list.dtos.wish.WishResponseDTO;
 import com.ofilipecode.wish_list.service.WishService;
 
@@ -33,6 +35,15 @@ public class WishController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @PutMapping("{id}")
+    public ResponseEntity<UpdateWishDTO> updateWish(@PathVariable UUID id, @RequestBody UpdateWishDTO dto) {
+
+        service.updateWish(id, dto);
+
+        return ResponseEntity.noContent().build();
+        
+    } 
 
     @GetMapping("{id}")
     public ResponseEntity<WishResponseDTO> getWishById(@PathVariable String id) {

--- a/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
@@ -37,7 +37,7 @@ public class WishController {
     }
 
     @PutMapping("{id}")
-    public ResponseEntity<UpdateWishDTO> updateWish(@PathVariable UUID id, @RequestBody UpdateWishDTO dto) {
+    public ResponseEntity<UpdateWishDTO> updateWish(@PathVariable UUID id, @RequestBody @Valid UpdateWishDTO dto) {
 
         service.updateWish(id, dto);
 

--- a/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
+++ b/src/main/java/com/ofilipecode/wish_list/controller/WishController.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,6 +48,7 @@ public class WishController {
         return ResponseEntity.ok(wishResponseDTO.get());
     }
 
+    @DeleteMapping("{id}")
     public ResponseEntity<Object> deleleWishById(@PathVariable String id) {
         UUID wishId = UUID.fromString(id);
 

--- a/src/main/java/com/ofilipecode/wish_list/dtos/wish/UpdateWishDTO.java
+++ b/src/main/java/com/ofilipecode/wish_list/dtos/wish/UpdateWishDTO.java
@@ -1,0 +1,16 @@
+package com.ofilipecode.wish_list.dtos.wish;
+
+import java.math.BigDecimal;
+
+import com.ofilipecode.wish_list.shared.enums.PriorityEnum;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateWishDTO(
+    @NotBlank String title,
+    @NotBlank String description,
+    @NotBlank String link,
+    @NotNull BigDecimal price,
+    @NotNull PriorityEnum priority
+) {}

--- a/src/main/java/com/ofilipecode/wish_list/service/WishService.java
+++ b/src/main/java/com/ofilipecode/wish_list/service/WishService.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import com.ofilipecode.wish_list.dtos.wish.CreateWishDTO;
+import com.ofilipecode.wish_list.dtos.wish.UpdateWishDTO;
 import com.ofilipecode.wish_list.dtos.wish.WishResponseDTO;
 import com.ofilipecode.wish_list.model.User;
 import com.ofilipecode.wish_list.model.Wish;
@@ -45,6 +46,35 @@ public class WishService {
             savedWish.getPriority(),
             savedWish.getUser().getId()
         );
+    }
+
+    public void updateWish(UUID id, UpdateWishDTO dto) {
+
+        // Pegar o Wish pelo ID passado na URL 
+        // Converter a String Id em UUID utilizando fromString
+        // Transformar o DTO em entidade
+        // Salvar a entidade no banco de dados 
+
+        Wish wish = repository.findById(id)
+            .orElseThrow(() -> new RuntimeException("Wish not found"));
+
+            if (dto.title() != null && !dto.title().isBlank()) {
+                wish.setTitle(dto.title());
+            }
+            if (dto.description() != null && !dto.description().isBlank()) {
+                wish.setDescription(dto.description());
+            }
+            if (dto.link() != null && !dto.link().isBlank()) {
+                wish.setLink(dto.link());
+            }
+            if (dto.price() != null) {
+                wish.setPrice(dto.price());
+            }
+            if (dto.priority() != null) {
+                wish.setPriority(dto.priority());
+            }
+
+            repository.save(wish);
     }
 
     public Optional<WishResponseDTO> getWishById(UUID id) {

--- a/src/main/java/com/ofilipecode/wish_list/service/WishService.java
+++ b/src/main/java/com/ofilipecode/wish_list/service/WishService.java
@@ -1,5 +1,6 @@
 package com.ofilipecode.wish_list.service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -44,5 +45,14 @@ public class WishService {
             savedWish.getPriority(),
             savedWish.getUser().getId()
         );
+    }
+
+    public Optional<WishResponseDTO> getWishById(UUID id) {
+        return repository.findById(id)
+            .map(wish -> new WishResponseDTO(wish.getId(), wish.getTitle(), wish.getDescription(), wish.getLink(), wish.getPrice(), wish.getPriority(), wish.getUser().getId()));
+    }
+
+    public void deleteById(UUID id) {
+        repository.findById(id).ifPresent(wish -> repository.delete(wish));
     }
 }

--- a/to-do.md
+++ b/to-do.md
@@ -12,7 +12,8 @@
 
 # Mais pro final do projeto
 
-- Refatorar o projeto adicionando a classe validation. (Deixar a regra de validação para essa camada da aplicação)
+- Refatorar o projeto adicionando a classe validation.
+- Tirar parte de validações da camada de controller
 - Adicionar JWT na aplicação
 - Documentar a API com Swagger
 - Subir deploy em nuvem grátis


### PR DESCRIPTION
Descrição:

This PR adds support for essential operations on the Wish entity, including:

    PUT /wishlist/{id} – Allows full update of a wish based on its ID.

    DELETE /wishlist/{id} – Deletes a wish by its unique identifier.

    GET /wishlist/{id} – Retrieves a specific wish using its ID.

These endpoints enhance the API's capability by providing standard CRUD operations for the Wish resource.
🔧 Changes

    Added endpoint to update an existing wish by ID.

    Added endpoint to delete a wish by ID.

    Added endpoint to retrieve a wish by ID.

    Applied consistent error handling for non-existent resources.

    Ensured response status codes follow RESTful conventions (200, 204, 404).

📎 Notes

    Input validation is handled on the update endpoint using appropriate annotations.

    Clear exception handling ensures proper feedback for invalid or missing resources.

    The update and delete operations return 204 No Content on success.

    The get-by-ID operation returns the full wish data with 200 OK.